### PR TITLE
Use cl-lib instead of cl.el

### DIFF
--- a/rcirc-styles.el
+++ b/rcirc-styles.el
@@ -1,6 +1,8 @@
 ;;; rcirc-styles.el --- support mIRC-style color and attribute codes
+
 ;; Package-Version: 20150720.001
 ;; Copyright 2015 Aaron Miller <me@aaron-miller.me>
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
@@ -68,9 +70,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
-
+(require 'cl-lib)
 (require 'rcirc)
 
 (defvar rcirc-styles-attribute-alist
@@ -134,7 +134,7 @@ mind when invoked outside that context."
     (goto-char (point-min))
 
     ;; walk along the message
-    (while (not (equalp (point) (point-max)))
+    (while (not (cl-equalp (point) (point-max)))
       
       ;; ^O means "turn off all formatting"
       (if (looking-at "\C-o")
@@ -239,7 +239,7 @@ mind when invoked outside that context."
          ranges
          attrs)
     (goto-char (point-min))
-    (while (not (equalp (point) (point-max)))
+    (while (not (cl-equalp (point) (point-max)))
       
       ;; ^O means "turn off all formatting"
       (if (looking-at "\C-o")
@@ -257,7 +257,7 @@ mind when invoked outside that context."
             (forward-char 1)
             (setq attrs
                   (if (member face attrs)
-                      (remove-if #'(lambda (e) (eq face e)) attrs)
+                      (cl-remove-if #'(lambda (e) (eq face e)) attrs)
                     (push face attrs)))
             ;; ...and, when there are attributes to apply, push a
             ;; range that does so.


### PR DESCRIPTION
This package should not load cl.el with 'eval-when-compile' because
this package uses cl functions. And we should use cl-lib.el rather than
cl.el now.

There are following byte-compile warning with original code.

```
In rcirc-styles-markup-colors:
rcirc-styles.el:137:18:Warning: function `equalp' from cl package called at
    runtime

In rcirc-styles-markup-attributes:
rcirc-styles.el:242:18:Warning: function `equalp' from cl package called at
    runtime
rcirc-styles.el:261:32:Warning: function `remove-if' from cl package called at
    runtime

In end of data:
rcirc-styles.el:341:1:Warning: the following functions might not be defined at ru\
ntime: equalp,
    remove-if
```
